### PR TITLE
Fix braces typo in IComparable csharp example

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/IComparable Example/CS/source.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/IComparable Example/CS/source.cs
@@ -23,7 +23,8 @@ public class Temperature : IComparable
         {
             return this.temperatureF;
         }
-        set {
+        set 
+        {
             this.temperatureF = value;
         }
     }


### PR DESCRIPTION
Just missing newline

